### PR TITLE
Add tasks that firewalld should be installed

### DIFF
--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -13,6 +13,9 @@
 - name: be sure postfix is running and enabled
   service: name=postfix state=running enabled=yes
 
+- name: be sure firewalld is installed
+  yum: name=firewalld state=installed
+
 - name: be stareted firewalld
   service: name=firewalld state=started enabled=yes
 

--- a/roles/redmine/tasks/main.yml
+++ b/roles/redmine/tasks/main.yml
@@ -26,6 +26,9 @@
 - name: yumアップデート実施
   yum: name=* state=latest
 
+- name: firewalld is installed
+  yum: name=firewalld state=installed
+
 - name: firewalld start
   service: name=firewalld state=started enabled=yes
 


### PR DESCRIPTION
Add tasks in roles/gitlab and roles/redmine;
Using the firewalld, but the instruction that the firewalld should be installed was missing.
