### PR TITLE
Unify settings concerned with the login user

### DIFF
--- a/gitlab.yml
+++ b/gitlab.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: gitlab
   become: yes
-  become_user: "{{ user }}"
+  user: "{{ user }}"
   roles:
    - gitlab
   environment: "{{ proxy_env }}"

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -2,7 +2,7 @@
 - name: jenkins
   hosts: jenkins
   become: yes
-  become_user: "{{ user }}"
+  user: "{{ user }}"
   roles:
     - jenkins
   environment: "{{ proxy_env }}"

--- a/redmine.yml
+++ b/redmine.yml
@@ -1,6 +1,6 @@
 - name: redmine
   hosts: redmine
-  sudo: yes
+  become: yes
   user: "{{ user }}"
   roles:
     - redmine

--- a/roles/redmine/tasks/main.yml
+++ b/roles/redmine/tasks/main.yml
@@ -159,8 +159,10 @@
     chdir=/var/lib/{{ redminever }}
 
 - name: セッション改ざん防止用秘密鍵の作成
-  shell:  /usr/local/bin/bundle exec /usr/local/bin/rake generate_secret_token
+  shell: /usr/local/bin/bundle exec /usr/local/bin/rake generate_secret_token
     chdir=/var/lib/{{ redminever }}
+  environment:
+    PATH: /usr/local/bin:$PATH
 
 - name: データベーステーブルの作成
   shell:
@@ -168,6 +170,7 @@
     chdir=/var/lib/{{ redminever }}
   environment:
     RAILS_ENV: production
+    PATH: /usr/local/bin:$PATH
 
 - name: passengerのインストール
   gem: name=passenger executable=/usr/local/bin/gem state=present user_install=False version={{ passengerver }}


### PR DESCRIPTION
- Unify the login user to the user in group_vars/all.  "become_user" is used in place of root user as sudo user.
- "sudo" is deprecated.
- Set the local path for the privilege escalation prompt because environment variables do not taken over.
