### PR TITLE
Use RPM Package to install Jenkins

### DIFF
--- a/roles/jenkins/README.md
+++ b/roles/jenkins/README.md
@@ -15,10 +15,10 @@ ansible's version is 1.9.4 or 2.0.0.1
     * yumで取得するopenjdkの名前
 * yum_repository_path
     * yumのrepositoryを管理しているpath
-* jenkins_repository
-    * jenkins repositoryのURL
 * jenkins_key
     * jenkins repository用の鍵があるURL
+* jekins_package_url
+    * jenkins rpm packageのURL
 * jenkins_host_name(default "localhost")
     * jenkinsのホストネーム
 * jenkins_port (default "8080")

--- a/roles/jenkins/tasks/deploy.yml
+++ b/roles/jenkins/tasks/deploy.yml
@@ -6,12 +6,6 @@
     - jenkins
     - deploy
 
-- name: Get jenkins repository
-  get_url: url={{ jenkins_repojitory }} dest={{ yum_repojitory_path }}
-  tags:
-    - jenkins
-    - deploy
-
 - name: Import jenkins key
   rpm_key: state=present key={{ jenkins_key }}
   tags:
@@ -19,7 +13,8 @@
     - deploy
 
 - name: Install jenkins
-  yum: name=jenkins state=latest update_cache=yes
+  yum: name={{ jekins_package_url }} state=present
+  ignore_errors: yes
   tags:
     - jenkins
     - deploy

--- a/roles/jenkins/vars/main.yml
+++ b/roles/jenkins/vars/main.yml
@@ -3,8 +3,8 @@ openjdk_items:
   - java-1.7.0-openjdk
   - java-1.7.0-openjdk-devel
 yum_repojitory_path: /etc/yum.repos.d
-jenkins_repojitory: http://pkg.jenkins-ci.org/redhat/jenkins.repo
 jenkins_key: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
+jekins_package_url: http://pkg.jenkins-ci.org/redhat/jenkins-1.658-1.1.noarch.rpm
 jenkins_host_name: localhost
 jenkins_port: 8080
 jenkins_updates_json_path: /var/lib/jenkins/updates/default.json


### PR DESCRIPTION
Initial setting procedure of Jenkins has changed in the new version (2.0).
If to support Jenkins 2.0, we need to rewrite the task to install the git plug-in.

As a temporary solution, specify the version (jenkins-1.658) using RPM package.
